### PR TITLE
Migrations-864 - Add report option for basic performance data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ setuptools.setup(
     py_modules=['traffic_comparator'],
     install_requires=[
         "Click",
-        "deepdiff"
+        "deepdiff",
+        "numpy"
     ],
     extras_require={
         'dev': ['flake8', 'pytest']

--- a/traffic_comparator/reports.py
+++ b/traffic_comparator/reports.py
@@ -88,14 +88,17 @@ class BasicCorrectnessReport(BaseReport):
 
 
 class PerformanceReport(BaseReport):
-    """Provides basic performance data
+    """Provides basic performance data including: average, median, p90 and p99 latencies.
+    Exported file also lists all latencies for recorded responses for primary and shadow clusters.
     """
     def compute(self) -> None:
-        self._prim_latencies = []
+        self._primary_latencies = []
         self._shadow_latencies = []
         for resp in self._response_comparisons:
-            self._prim_latencies.append(resp.primary_response.latency)
-            self._shadow_latencies.append(resp.shadow_response.latency)
+            if resp.primary_response.latency > 0:
+                self._primary_latencies.append(resp.primary_response.latency)
+            if resp.shadow_response.latency > 0:
+                self._shadow_latencies.append(resp.shadow_response.latency)
 
         self._computed = True
 
@@ -108,16 +111,16 @@ class PerformanceReport(BaseReport):
 
         return f"""
             ==Stats for primary cluster==
-    99th percentile = {np.percentile(self._prim_latencies, 99)}
-    90th percentile = {np.percentile(self._prim_latencies, 90)}
-    50th percentile = {np.percentile(self._prim_latencies, 50)}
-    Average Latency = {np.average(self._prim_latencies)}
+    99th percentile = {'%.1f' % np.percentile(self._primary_latencies, 99)}
+    90th percentile = {'%.1f' % np.percentile(self._primary_latencies, 90)}
+    50th percentile = {'%.1f' % np.percentile(self._primary_latencies, 50)}
+    Average Latency = {'%.1f' % np.average(self._primary_latencies)}
     
             ==Stats for shadow cluster==
-    99th percentile = {np.percentile(self._shadow_latencies, 99)}
-    90th percentile = {np.percentile(self._shadow_latencies, 90)}
-    50th percentile = {np.percentile(self._shadow_latencies, 50)}
-    Average Latency = {np.average(self._shadow_latencies)}
+    99th percentile = {'%.1f' % np.percentile(self._shadow_latencies, 99)}
+    90th percentile = {'%.1f' % np.percentile(self._shadow_latencies, 90)}
+    50th percentile = {'%.1f' % np.percentile(self._shadow_latencies, 50)}
+    Average Latency = {'%.1f' % np.average(self._shadow_latencies)}
     """
 
     def export(self, output_file: IO) -> None:
@@ -127,7 +130,7 @@ class PerformanceReport(BaseReport):
         output_file.write("\n")
         #For now, this is only exporting the basic performance data and lists all latencies recorded on each cluster
         output_file.write("All Primary Cluster Latencies: \n")
-        for lat in self._prim_latencies:
+        for lat in self._primary_latencies:
             output_file.write(repr(lat) + " ")
 
         output_file.write("\n")


### PR DESCRIPTION
Signed-off-by: Omar Khasawneh <okhasawn@amazon.com>

### Description
This PR adds the option of generating a basic performance report, which has some basic performance metrics. (p90, p99, median and average).

Example output:

```
PerformanceReport:


            ==Stats for primary cluster==
    99th percentile = 528.28
    90th percentile = 350.80000000000007
    50th percentile = 40.0
    Average Latency = 135.6
    
            ==Stats for shadow cluster==
    99th percentile = 520.4
    90th percentile = 344.00000000000006
    50th percentile = 40.0
    Average Latency = 135.0
```

### Issues Resolved
[Migrations-864](https://opensearch.atlassian.net/browse/MIGRATIONS-864)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
