### PR TITLE
Add linting (flake8) workflow to repo

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+     - name: Checkout Repository
+       uses: actions/checkout@v3
+
+     - name: Set up Python ${{ matrix.python-version }}
+       uses: actions/setup-python@v3
+       with:
+         python-version: ${{ matrix.python-version }}
+     - name: Install dependencies
+       run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+     - name: Analysing the code with flake8
+       run: |
+        flake8 $(git ls-files '*.py')


### PR DESCRIPTION
### Description
Adds linting workflow to the repo which applies the flake8 rules existing in the `.flake8` file, to the .py files in a PR when it's created.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
