### PR TITLE
Migrations-1016 - Add initial maintainer files to repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
+*   @opensearch-project/opensearch-migrations

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+### Description
+[Describe what this change achieves]
+* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
+* Why these changes are required?
+* What is the old behavior before changes and new behavior after changes?
+
+### Issues Resolved
+[List any issues this PR will resolve]
+
+Is this a backport? If so, please add backport PR # and/or commits #
+
+### Testing
+[Please provide details of testing done: unit testing, integration testing and manual testing]
+
+### Check List
+- [ ] New functionality includes testing
+  - [ ] All tests pass, including unit test, integration test and doctest
+- [ ] New functionality has been documented
+- [ ] Commits are signed per the DCO using --signoff
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
+For more information on following Developer Certificate of Origin and signing off your commits, please check 
+[here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

--- a/.github/release-notes-drafter-config.yml
+++ b/.github/release-notes-drafter-config.yml
@@ -1,0 +1,24 @@
+# Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
+template: |
+  Compatible with OpenSearch (set version here).
+  $CHANGES
+
+# Setting the formatting and sorting for the release notes body
+name-template: Version (set version here)
+change-template: '* $TITLE ([#$NUMBER](https://github.com/opensearch-project/traffic-comparator/pull/$NUMBER))'
+sort-by: merged_at
+sort-direction: ascending
+replacers:
+  - search: "##"
+    replace: "###"
+
+# Organizing the tagged PRs into unified ODFE categories
+categories:
+  - title: "Enhancements"
+    labels: "enhancement"
+
+  - title: "Bug fixes"
+    labels: "bug"
+
+  - title: "Maintenance"
+    labels: "maintenance"

--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -1,0 +1,17 @@
+## Overview
+
+This document contains a list of maintainers in this repo. See 
+[opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, 
+what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
+
+| Maintainer         | GitHub ID                                               | Affiliation |
+| ------------------ | ------------------------------------------------------- | ----------- |
+| Chris Helma        | [chelma](https://github.com/chelma)                     | Amazon      |
+| Greg Schohn        | [gregschohn](https://github.com/gregschohn)             | Amazon      |
+| Kartik Ganesh      | [kartg](https://github.com/kartg)                       | Amazon      |
+| Tanner Lewis       | [lewijacn](https://github.com/lewijacn)                 | Amazon      |
+| Mikayla Thompson   | [mikaylathompson](https://github.com/mikaylathompson)   | Amazon      |
+| Omar Khasawneh     | [okhasawn](https://github.com/okhasawn)                 | Amazon      |
+| Brian Presley      | [sumobrian](https://github.com/sumobrian)               | Amazon      |


### PR DESCRIPTION
### Description
Adds files required in order to make the repo public.

### Issues Resolved
[Migrations-1016](https://opensearch.atlassian.net/browse/MIGRATIONS-1016)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
