### PR TITLE
Improve matching: lower case headers & more masked fields

### DIFF
--- a/tests/test_response_comparison.py
+++ b/tests/test_response_comparison.py
@@ -195,3 +195,9 @@ def test_WHEN_responses_differ_on_header_case_THEN_comparison_suceeeds():
     assert response_comparison.headers_diff == {}
     assert response_comparison.body_diff == {}
     assert response_comparison.are_identical()
+
+    # Currently the init function for a Response forcibly lowercases all header names.
+    # This changes the source of truth values, which is probably not what we want to do long-term.
+    # Leaving this assert in here as a reminder of this change.
+    # TODO: Preserve original casing for header names, while not flagging this as a comparison issue.
+    assert 'Content-Type' not in os_response.headers.keys()

--- a/tests/test_response_comparison.py
+++ b/tests/test_response_comparison.py
@@ -1,3 +1,4 @@
+import base64
 import json
 
 import pytest
@@ -173,6 +174,22 @@ def test_WHEN_responses_differ_on_masked_fields_THEN_comparison_suceeds():
                            body=MASKING_RESPONSE_BODY_1)
     os_response = Response(headers={'content-length': 572},
                            body=MASKING_RESPONSE_BODY_2)
+    response_comparison = ResponseComparison(es_response, os_response)
+    assert response_comparison.status_code_diff == {}
+    assert response_comparison.headers_diff == {}
+    assert response_comparison.body_diff == {}
+    assert response_comparison.are_identical()
+
+
+def dictToBase64JsonBytes(d: dict) -> bytes:
+    return base64.b64encode(json.dumps(d).encode('utf-8'))
+
+
+def test_WHEN_responses_differ_on_header_case_THEN_comparison_suceeeds():
+    es_response = Response(headers={'content-type': 'application/json'},
+                           raw_body=dictToBase64JsonBytes(MASKING_RESPONSE_BODY_1))
+    os_response = Response(headers={'Content-Type': 'application/json'},
+                           raw_body=dictToBase64JsonBytes(MASKING_RESPONSE_BODY_1))
     response_comparison = ResponseComparison(es_response, os_response)
     assert response_comparison.status_code_diff == {}
     assert response_comparison.headers_diff == {}

--- a/traffic_comparator/data.py
+++ b/traffic_comparator/data.py
@@ -120,6 +120,10 @@ class Response:
         self.body = parseBodyAsJson(decoded_body)  # Responses are never bulk calls
         self.raw_body = None
 
+        # Process the headers to make all keys lower case, allowing for more consistent comparisons.
+        # TODO: Is this fair? does this every change behavior?
+        self.headers = {k.lower(): v for k, v in self.headers.items()} if self.headers else None
+
 
 @dataclass
 class RequestResponsePair:

--- a/traffic_comparator/data.py
+++ b/traffic_comparator/data.py
@@ -121,7 +121,6 @@ class Response:
         self.raw_body = None
 
         # Process the headers to make all keys lower case, allowing for more consistent comparisons.
-        # TODO: Is this fair? does this every change behavior?
         self.headers = {k.lower(): v for k, v in self.headers.items()} if self.headers else None
 
 

--- a/traffic_comparator/response_comparison.py
+++ b/traffic_comparator/response_comparison.py
@@ -40,7 +40,7 @@ class ResponseComparison:
 
         # Depending on the performance of DeepDiff on large bodies, this could be pulled out to an async function.
         self._status_code_diff = DeepDiff(primary_response.statuscode, shadow_response.statuscode)
-        self._headers_diff = DeepDiff(primary_response.headers, shadow_response.headers, ignore_string_case=True,
+        self._headers_diff = DeepDiff(primary_response.headers, shadow_response.headers,
                                       exclude_paths=HEADER_PATHS_TO_IGNORE)
         self._body_diff = DeepDiff(primary_response.body, shadow_response.body,
                                    exclude_paths=BODY_PATHS_TO_IGNORE)

--- a/traffic_comparator/response_comparison.py
+++ b/traffic_comparator/response_comparison.py
@@ -24,8 +24,9 @@ class MissingFieldForLoadingComparisonJsonException(Exception):
 # In a future task (MIGRATIONS-863), this will be made customizable by the user, but for
 # now, they're being hardcoded and will be updated as we test against new response types.
 BODY_PATHS_TO_IGNORE = ["root['cluster_name']", "root['cluster_uuid']", "root['name']", "root['took']",
-                        "root['tagline']", "root['version']"]
-HEADER_PATHS_TO_IGNORE = ["content-length"]
+                        "root['tagline']", "root['version']", "root['_id']", "root['_shards']", "root['_seq_no']"]
+HEADER_PATHS_TO_IGNORE = ["content-length", "access-control-allow-origin", "connection", "date",
+                          "location"]
 
 
 class ResponseComparison:
@@ -39,7 +40,7 @@ class ResponseComparison:
 
         # Depending on the performance of DeepDiff on large bodies, this could be pulled out to an async function.
         self._status_code_diff = DeepDiff(primary_response.statuscode, shadow_response.statuscode)
-        self._headers_diff = DeepDiff(primary_response.headers, shadow_response.headers,
+        self._headers_diff = DeepDiff(primary_response.headers, shadow_response.headers, ignore_string_case=True,
                                       exclude_paths=HEADER_PATHS_TO_IGNORE)
         self._body_diff = DeepDiff(primary_response.body, shadow_response.body,
                                    exclude_paths=BODY_PATHS_TO_IGNORE)


### PR DESCRIPTION
Signed-off-by: Mikayla Thompson <thomika@amazon.com>

### Description
This PR improves matching performance on some datasets by 1/ making all header keys lower case when they're ingested, and 2/ adding some fields to the masking lists for body and header.

The header adjustments are driven by the fact that default-configured ES, running on EC2, and default-configured OS running on the managed service return quite different headers:
```
- Headers: {'content-length': '171', 'content-type': 'application/json; charset=UTF-8', 'Location': '/logs/_doc/Dr6LcYcBBgZSvW1Wc65t'}
+ Headers: {'access-control-allow-origin': '*', 'Connection': 'keep-alive', 'Content-Length': '171', 'Date': 'Tue, 11 Apr 2023 21:12:08 GMT', 'Content-Type': 'application/json; charset=UTF-8'}
```


### Issues Resolved
No issues created


### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [x] New functionality includes testing
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check 
[here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
