### PR TITLE
Removing masked fields from diffs visualization

### DIFF
--- a/traffic_comparator/reports.py
+++ b/traffic_comparator/reports.py
@@ -49,7 +49,8 @@ class DiffReport(BaseReport):
     def parse_masked_fields() -> None:
         for body in BODY_PATHS_TO_IGNORE:
             result = re.search(r"root\[\'(.*)\'\]", body)
-            body = result.group(1)
+            if result:
+                body = result.group(1)
             PARSED_BODY_PATHS_TO_IGNORE.append(body)
 
     # As we're comparing the responses from two clusters, the user can specify which fields they want masked, and there


### PR DESCRIPTION
### Description
This change will remove the masked fields from the final display of diffs between the response comparisons (Shadow vs Primary).

Also adds logging to certain places.

### Issues Resolved
[Migrations-1013](https://opensearch.atlassian.net/browse/MIGRATIONS-1013) + [Migrations-994](https://opensearch.atlassian.net/browse/MIGRATIONS-994)

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check 
[here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
