### PR TITLE
MIGRATIONS-1076 - Create Jupyter data exploration environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,58 +190,8 @@ pytest
 
 Currently, comparison results can be reported in very high level reports (average latencies, percent of matching status codes), or in very low level detail (all line-by-line diffs output to a file). Neither of these formats are conducive to data exploration or visualization.
 
-A new option has been added: comparison results can be dumped to a sqlite database, and then read in using some provided functions in a Jupyter Notebook or IPython terminal, and explored and visualized there.
+Comparison results can also be dumped to a sqlite database, thereby allowing the comparison data to be visualized via a Jupyter Notebook or IPython terminal.
 
-The following is a walk through of the sample `Results Repository.ipynb` file.
+It is possible to use either Jupyter notebooks (web-based UI to a local server that runs the python kernel) or in an IPython terminal (command line terminal with kernel running directly) to visualize comparison data. For a detailed walkthrough of the sample notebook, see [JupyterGuide.md](jupyterguide.md).
+If you know what you're doing, the results can be dumped to a sqlite database with `trafficcomparator dump-to-sqlite` and the Jupyter server can be started with `jupyter notebook`.
 
-### Install Data Exploration-specific Dependencies
-
-```
-pip install --editable ".[data]"
-```
-
-### Dump Comparison Results to SQLite
-
-A command has been added that handles accepting comparison results and dumping them to sqlite in the appropriate format.
-
-If you're doing your comparison at the same time, it can be run as in the following example, with any of the possible settings from above. It supports running in streaming mode and will flush each write to the sqlite db.
-
-```
-cat input_triples.log | trafficcomparator stream | trafficcomparator dump-to-sqlite
-```
-
-If you have already generated comparisons (e.g. run the `stream` command) and saved the output, you can pipe that directly into the `dump-to-sqlite` command.
-
-```
-cat comparison_results.log | trafficcomparator dump-to-sqlite
-```
-
-### Start the Jupyter server and load results
-It is possible to run all of the following either in a Jupyter notebook (web-based notebook UI to a local server that runs the python kernel) or in an IPython terminal (command line terminal with kernel running directly).
-
-For the sake of illustration + better visualizations, I'm going to walk through the Jupyter notebook technique here.
-
-Start the server with `jupyter notebook`.
-
-You'll see a bunch of text along the lines of:
-```
-[I 16:00:25.491 NotebookApp] Serving notebooks from local directory: ~/code/traffic-comparator
-[I 16:00:25.491 NotebookApp] Jupyter Notebook 6.5.4 is running at:
-[I 16:00:25.491 NotebookApp] http://localhost:8888/?token=f8929f...
-```
-
-It should also open a window in your default webbrowser at http://localhost:8888/tree that shows the contents of this directory. You can create a new notebook in the upper right, but for the sake of this walkthrough, open `Result Repository.ipynb`.
-
-Start with the first cell, which has all of the necessary imports. Click into it, and then execute it with shift-enter. Assuming you have all the dependencies installed, there should be no output and it will move your focus to the next cell.
-
-The second cell handles the bulk of loading in the data from the database.
-It establishes the path to the db (you can change this if you're done something custom), opens a connection to it, and then guesses the table you'd like to load. It defaults to the latest created table (assuming they were all created with the `dump-to-sqlite` command), but you can change the value of `table_name` if you'd like it to load a different one.
-
-Then it executes a `READ *` command on that table and loads all of the data into a [Pandas dataframe](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html). Pandas will be the main library used for exploring and managing the data, so it's worth reading through the quickstart guide if you're not familiar with it: https://pandas.pydata.org/docs/getting_started/intro_tutorials/01_table_oriented.html.
-
-This cell also applies two utility functions to the data after loading it in. First, it uses a list that specifies which columns are json to attempt loading the fields as JSON and overwriting their values if succesful. Second, it looks for a `took` field in the body of each response and populates a new column with that value.
-
-The last line (`df.head()`) prints the first five lines of the dataframe, as a way to preview the data and check that it loaded as expected.
-
-The contents of these two cells are pretty universal -- you'll probably want to perform these operations for any projects you do with this data.
-The rest of the code is much more specific to particular questions and explorations that I was curious about. My goal was to both answer real questions, and showcase some of the capabilities of Pandas and Jupyter Notebook for this application.

--- a/README.md
+++ b/README.md
@@ -185,3 +185,63 @@ In this directory (you should see the `test` and `traffic_comparator` directorie
 ```
 pytest
 ```
+
+## Exploring Results in Jupyter Notebook/IPython
+
+Currently, comparison results can be reported in very high level reports (average latencies, percent of matching status codes), or in very low level detail (all line-by-line diffs output to a file). Neither of these formats are conducive to data exploration or visualization.
+
+A new option has been added: comparison results can be dumped to a sqlite database, and then read in using some provided functions in a Jupyter Notebook or IPython terminal, and explored and visualized there.
+
+The following is a walk through of the sample `Results Repository.ipynb` file.
+
+### Install Data Exploration-specific Dependencies
+
+```
+pip install --editable ".[data]"
+```
+
+### Dump Comparison Results to SQLite
+
+A command has been added that handles accepting comparison results and dumping them to sqlite in the appropriate format.
+
+If you're doing your comparison at the same time, it can be run as in the following example, with any of the possible settings from above. It supports running in streaming mode and will flush each write to the sqlite db.
+
+```
+cat input_triples.log | trafficcomparator stream | trafficcomparator dump-to-sqlite
+```
+
+If you have already generated comparisons (e.g. run the `stream` command) and saved the output, you can pipe that directly into the `dump-to-sqlite` command.
+
+```
+cat comparison_results.log | trafficcomparator dump-to-sqlite
+```
+
+### Start the Jupyter server and load results
+It is possible to run all of the following either in a Jupyter notebook (web-based notebook UI to a local server that runs the python kernel) or in an IPython terminal (command line terminal with kernel running directly).
+
+For the sake of illustration + better visualizations, I'm going to walk through the Jupyter notebook technique here.
+
+Start the server with `jupyter notebook`.
+
+You'll see a bunch of text along the lines of:
+```
+[I 16:00:25.491 NotebookApp] Serving notebooks from local directory: ~/code/traffic-comparator
+[I 16:00:25.491 NotebookApp] Jupyter Notebook 6.5.4 is running at:
+[I 16:00:25.491 NotebookApp] http://localhost:8888/?token=f8929f...
+```
+
+It should also open a window in your default webbrowser at http://localhost:8888/tree that shows the contents of this directory. You can create a new notebook in the upper right, but for the sake of this walkthrough, open `Result Repository.ipynb`.
+
+Start with the first cell, which has all of the necessary imports. Click into it, and then execute it with shift-enter. Assuming you have all the dependencies installed, there should be no output and it will move your focus to the next cell.
+
+The second cell handles the bulk of loading in the data from the database.
+It establishes the path to the db (you can change this if you're done something custom), opens a connection to it, and then guesses the table you'd like to load. It defaults to the latest created table (assuming they were all created with the `dump-to-sqlite` command), but you can change the value of `table_name` if you'd like it to load a different one.
+
+Then it executes a `READ *` command on that table and loads all of the data into a [Pandas dataframe](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html). Pandas will be the main library used for exploring and managing the data, so it's worth reading through the quickstart guide if you're not familiar with it: https://pandas.pydata.org/docs/getting_started/intro_tutorials/01_table_oriented.html.
+
+This cell also applies two utility functions to the data after loading it in. First, it uses a list that specifies which columns are json to attempt loading the fields as JSON and overwriting their values if succesful. Second, it looks for a `took` field in the body of each response and populates a new column with that value.
+
+The last line (`df.head()`) prints the first five lines of the dataframe, as a way to preview the data and check that it loaded as expected.
+
+The contents of these two cells are pretty universal -- you'll probably want to perform these operations for any projects you do with this data.
+The rest of the code is much more specific to particular questions and explorations that I was curious about. My goal was to both answer real questions, and showcase some of the capabilities of Pandas and Jupyter Notebook for this application.

--- a/Results Repository.ipynb
+++ b/Results Repository.ipynb
@@ -1,0 +1,184 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "241006b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from pathlib import Path\n",
+    "import sqlite3\n",
+    "\n",
+    "from traffic_comparator.sqlite import COLUMN_DATATYPES, COLUMN_JSONS, json_load_function, get_took_value, get_latest_table_name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "340ac0eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db_file = Path(\"comparisons.db\")\n",
+    "con = sqlite3.connect(db_file)\n",
+    "cur = con.cursor()\n",
+    "# By default, this reads from the latest table, but this can be modified to a specific table name instead.\n",
+    "table_name = get_latest_table_name(cur)\n",
+    "df = pd.read_sql_query(f\"SELECT * from {table_name}\", con,\n",
+    "                       dtype=COLUMN_DATATYPES)\n",
+    "con.close()\n",
+    "\n",
+    "# This loads the text from each of the `table_json_fields` as a python dictionary\n",
+    "for column in COLUMN_JSONS:\n",
+    "    df[column] = df[column].apply(json_load_function)\n",
+    "    \n",
+    "# This creates the source and target `took` fields by extracting the took value from the response bodies.\n",
+    "df['source_took'] = df['source_response_body'].apply(get_took_value)\n",
+    "df['target_took'] = df['target_response_body'].apply(get_took_value)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc208dae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e329d114",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Measured Latency\")\n",
+    "print(df['target_response_latency'].describe())\n",
+    "print()\n",
+    "print(\"Took field\")\n",
+    "print(df['target_took'].describe())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "179b1149",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Latency plot\n",
+    "plt.subplot(2, 1, 1)\n",
+    "_, bins, _ = plt.hist([df['source_response_latency'], df['target_response_latency']], bins=60, range=(0, 300), histtype='stepfilled', alpha=0.8)\n",
+    "plt.axvline(df['source_response_latency'].median(), color='k', linestyle='dashed', linewidth=1)\n",
+    "plt.axvline(df['target_response_latency'].median(), color='k', linestyle='dashed', linewidth=1)\n",
+    "\n",
+    "plt.title(\"Measured latency of source vs target cluster\")\n",
+    "plt.xlabel(\"Latency (ms)\")\n",
+    "plt.ylabel(\"Count\")\n",
+    "\n",
+    "# Took plot\n",
+    "plt.subplot(2, 1, 2)\n",
+    "plt.hist([df['source_took'], df['target_took']], bins=bins, histtype='stepfilled', alpha=0.7)\n",
+    "plt.axvline(df['source_took'].median(), color='k', linestyle='dashed', linewidth=1)\n",
+    "plt.axvline(df['target_took'].median(), color='k', linestyle='dashed', linewidth=1)\n",
+    "plt.title(\"Reported latency (\\\"took\\\") of source vs target cluster\")\n",
+    "plt.xlabel(\"Latency (ms)\")\n",
+    "plt.ylabel(\"Count\")\n",
+    "plt.tight_layout()\n",
+    "\n",
+    "\n",
+    "print(f\"Source median latency: {df['source_response_latency'].median():.2f} ms\")\n",
+    "print(f\"Target median latency: {df['target_response_latency'].median():.2f} ms\")\n",
+    "plt.show()\n",
+    "print(f\"Source median 'took': {df['source_took'].median():.2f} ms\")\n",
+    "print(f\"Target median 'took': {df['target_took'].median():.2f} ms\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5751cd60",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Estimate the network latency\n",
+    "print(\"Source cluster network latency\")\n",
+    "print((df['source_response_latency'] - df['source_took']).mean())\n",
+    "print()\n",
+    "print(\"Target cluster network latency\")\n",
+    "print((df['target_response_latency'] - df['target_took']).mean())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "989dc230",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uri_groups = df.groupby(['request_uri', 'request_method'])\n",
+    "uri_groups.aggregate(func={'responses_are_identical': lambda x: f\"{x.mean():.2%}\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b659080",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uri_groups.size()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "038afdf3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bulk_df = df[df[\"request_uri\"] == \"/_bulk\"]\n",
+    "bulk_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27f9e58c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0rc2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,5 @@
 import logging
+import pathlib
 import sys
 from typing import IO, List, Tuple
 
@@ -7,6 +8,7 @@ import click
 from traffic_comparator.analyzer import StreamingAnalyzer
 from traffic_comparator.data_loader import StreamingDataLoader
 from traffic_comparator.report_generator import StreamingReportGenerator
+from traffic_comparator.sqlite import SqliteDumper
 
 
 # Click is a python library that streamlines creating command line interfaces
@@ -60,6 +62,15 @@ def stream_report(export_reports: List[Tuple[str, IO]]):
     for report, export_file in export_reports:
         report_generator.generate_final_report(report, export_file)
         click.echo(f"{report} was exported to {export_file.name}")
+
+
+@cli.command()
+def dump_to_sqlite():
+    database_file = pathlib.Path('comparisons.db')
+    sqlite_dumper = SqliteDumper(database_file)
+    for line in sys.stdin:
+        sqlite_dumper.update(line)
+    sqlite_dumper.close()
 
 
 @cli.command()

--- a/jupyterguide.md
+++ b/jupyterguide.md
@@ -1,0 +1,58 @@
+# Intro
+
+It is possible to use either Jupyter notebooks (web-based UI to a local server that runs the python kernel) or in an IPython terminal (command line terminal with kernel running directly) to visualize comparison data.
+
+# Walkthrough
+
+### Install Data Exploration-specific Dependencies
+
+```
+pip install --editable ".[data]"
+```
+
+### Dump Comparison Results to SQLite
+
+A command has been added that handles accepting comparison results and dumping them to sqlite in the appropriate format.
+
+If you're doing your comparison at the same time, it can be run as in the following example, with any of the possible settings from above. It supports running in streaming mode and will flush each write to the sqlite db.
+
+```
+cat input_triples.log | trafficcomparator stream | trafficcomparator dump-to-sqlite
+```
+
+If you have already generated comparisons (e.g. run the `stream` command) and saved the output, you can pipe that directly into the `dump-to-sqlite` command.
+
+```
+cat comparison_results.log | trafficcomparator dump-to-sqlite
+```
+
+### Start the Jupyter server and load results
+It is possible to run all of the following either in a Jupyter notebook (web-based notebook UI to a local server that runs the python kernel) or in an IPython terminal (command line terminal with kernel running directly).
+
+For the sake of illustration + better visualizations, I'm going to walk through the Jupyter notebook technique here.
+
+Start the server with `jupyter notebook`.
+
+You'll see a bunch of text along the lines of:
+```
+[I 16:00:25.491 NotebookApp] Serving notebooks from local directory: ~/code/traffic-comparator
+[I 16:00:25.491 NotebookApp] Jupyter Notebook 6.5.4 is running at:
+[I 16:00:25.491 NotebookApp] http://localhost:8888/?token=f8929f...
+```
+
+It should also open a window in your default webbrowser at http://localhost:8888/tree that shows the contents of this directory. You can create a new notebook in the upper right, but for the sake of this walkthrough, open `Result Repository.ipynb`.
+
+Start with the first cell, which has all of the necessary imports. Click into it, and then execute it with shift-enter. Assuming you have all the dependencies installed, there should be no output and it will move your focus to the next cell.
+
+The second cell handles the bulk of loading in the data from the database.
+It establishes the path to the db (you can change this if you're done something custom), opens a connection to it, and then guesses the table you'd like to load. It defaults to the latest created table (assuming they were all created with the `dump-to-sqlite` command), but you can change the value of `table_name` if you'd like it to load a different one.
+
+Then it executes a `READ *` command on that table and loads all of the data into a [Pandas dataframe](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html). Pandas will be the main library used for exploring and managing the data, so it's worth reading through the quickstart guide if you're not familiar with it: https://pandas.pydata.org/docs/getting_started/intro_tutorials/01_table_oriented.html.
+
+This cell also applies two utility functions to the data after loading it in. First, it uses a list that specifies which columns are json to attempt loading the fields as JSON and overwriting their values if succesful. Second, it looks for a `took` field in the body of each response and populates a new column with that value.
+
+The last line (`df.head()`) prints the first five lines of the dataframe, as a way to preview the data and check that it loaded as expected.
+
+The contents of these two cells are pretty universal -- you'll probably want to perform these operations for any projects you do with this data.
+The rest of the code is much more specific to particular questions and explorations that I was curious about. My goal was to both answer real questions, and showcase some of the capabilities of Pandas and Jupyter Notebook for this application.
+

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,10 @@ setuptools.setup(
         "numpy"
     ],
     extras_require={
-        'dev': ['flake8', 'pytest']
+        'dev': ['flake8', 'pytest'],
+        'data': ['jupyter', 'pandas', 'matplotlib']
     },
-    python_requires=">=3.6",
+    python_requires=">=3.9",
     entry_points={
         'console_scripts': [
             'trafficcomparator = cli:cli'

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -1,0 +1,36 @@
+from traffic_comparator.sqlite import (COLUMN_DATATYPES, COLUMN_JSONS, COLUMNS,
+                                       get_took_value, json_load_function)
+
+
+def test_column_list_sanity_checks():
+    # These prove the assertions in the descriptions of the COLUMN objects
+
+    # COLUMN_DATATYPES contains the same items as COLUMNS
+    assert sorted(list(COLUMN_DATATYPES.keys())) == sorted(COLUMNS)
+
+    # COLUMN_JSONS is a subset of COLUMNS
+    for entry in COLUMN_JSONS:
+        assert entry in COLUMNS
+
+
+def test_json_load_function_happy_path():
+    json_string = """{"hello": "world", "goodnight": ["moon", "noises everywhere"]}"""
+    actual_dict = {"hello": "world", "goodnight": ["moon", "noises everywhere"]}
+
+    assert actual_dict == json_load_function(json_string)
+
+
+def test_json_laod_function_invalid_json_returns_original_string():
+    invalid_json_string = """{"hello": "world" """
+
+    assert invalid_json_string == json_load_function(invalid_json_string)
+
+
+def test_get_took_value_happy_path():
+    body = {"result": "xyz", "more_body_contents": "abc", "took": 194, "different_int": 49}
+    assert 194 == get_took_value(body)
+
+
+def test_get_took_value_no_took_field():
+    body = {"result": "xyz", "more_body_contents": "abc", "different_int": 49}
+    assert get_took_value(body) is None

--- a/traffic_comparator/sqlite.py
+++ b/traffic_comparator/sqlite.py
@@ -1,0 +1,191 @@
+import json
+import logging
+import pathlib
+import sqlite3
+from typing import Optional, Union
+
+from traffic_comparator.response_comparison import (
+    InvalidJsonForLoadingComparisonException,
+    MissingFieldForLoadingComparisonJsonException, ResponseComparison)
+
+logger = logging.getLogger(__name__)
+
+
+COLUMNS = ['request_uri', 'request_method', 'request_timestamp', 'request_headers', 'request_body',
+           'source_response_timestamp', 'source_response_status', 'source_response_headers', 'source_response_body', 'source_response_latency',  # noqa: E501
+           'target_response_timestamp', 'target_response_status', 'target_response_headers', 'target_response_body', 'target_response_latency',  # noqa: E501
+           'responses_are_identical', 'headers_diff', 'bodies_diff']
+
+# This is a dict of the above columns, listing those that should be loaded with a specific pandas datatype.
+COLUMN_DATATYPES = {
+    "request_uri": "string",
+    "request_method": "string",
+    "request_timestamp": "datetime64[ns]",
+    "request_headers": "string",
+    "request_body": "string",
+    "source_response_timestamp": "datetime64[ns]",
+    "source_response_status": "category",
+    "source_response_headers": "string",
+    "source_response_body": "string",
+    "source_response_latency": int,
+    "target_response_timestamp": "datetime64[ns]",
+    "target_response_status": "category",
+    "target_response_headers": "string",
+    "target_response_body": "string",
+    "target_response_latency": int,
+    "responses_are_identical": int,  # This value is actually a bool, but sqlite treats it as an int
+                                     # and that has convenient effects on the pandas side
+    "headers_diff": "string",
+    "bodies_diff": "string"
+}
+
+# This is also a subset of both COLUMNS and COLUMN_DATATYPES for those that should be parsed as JSONs.
+COLUMN_JSONS = [
+    "request_headers",
+    "request_body",
+    "source_response_headers",
+    "source_response_body",
+    "target_response_headers",
+    "target_response_body",
+    "headers_diff",
+    "bodies_diff"
+]
+
+
+def json_load_function(x: str) -> Union[str, dict]:
+    """This is a utility functions used in the notebook to parse the json data."""
+    try:
+        return json.loads(x)
+    except json.JSONDecodeError:
+        return x
+
+
+def get_took_value(body: dict) -> Optional[int]:
+    """This is used in the notebook to calculate the "took" value, a more accurate measure of latency."""
+    if 'took' in body:
+        return body['took']
+    return None
+
+
+# Functions for dumping to SQLite
+
+
+def format_headers(headers: Union[dict, str, None]) -> str:
+    if type(headers) is dict:
+        return json.dumps(headers)
+    elif type(headers) is str:
+        return headers
+    return ''
+
+
+def format_body(body: Union[dict, str, list, None]) -> str:
+    if type(body) in [dict, list]:
+        return json.dumps(body)
+    elif type(body) is str:
+        return body
+    assert body is None
+    return ''
+
+
+class dbComparisonTable:
+    def __init__(self, table_name) -> None:
+        self.name = table_name
+
+    def createTable(self, cursor: sqlite3.Cursor):
+        column_names = ','.join(COLUMNS)
+        command = f"CREATE TABLE {self.name}({column_names})"
+        logger.debug(f"Command to create table: {command}")
+        cursor.execute(command)
+
+
+class dbComparisonRow:
+    def __init__(self, table: dbComparisonTable, comp: ResponseComparison):
+        self.table = table
+        
+        if comp.original_request:
+            self.request_uri = comp.original_request.uri
+            self.request_method = comp.original_request.http_method
+            self.request_timestamp = comp.original_request.timestamp
+            self.request_headers = format_headers(comp.original_request.headers)
+            self.request_body = format_body(comp.original_request.body)
+
+        if comp.primary_response:
+            self.source_response_status = comp.primary_response.statuscode
+            self.source_response_headers = format_headers(comp.primary_response.headers)
+            self.source_response_body = format_body(comp.primary_response.body)
+            self.source_response_latency = comp.primary_response.latency
+
+        if comp.shadow_response:
+            self.target_response_status = comp.shadow_response.statuscode
+            self.target_response_headers = format_headers(comp.shadow_response.headers)
+            self.target_response_body = format_body(comp.shadow_response.body)
+            self.target_response_latency = comp.shadow_response.latency
+
+        self.responses_are_identical = comp.are_identical()
+        self.headers_diff = str(comp.headers_diff)
+        self.bodies_diff = str(comp.body_diff)
+
+    def writeRow(self, cursor: sqlite3.Cursor):
+        values = {}
+        for c in COLUMNS:
+            if c in self.__dict__ and self.__dict__[c] is not None:
+                value = self.__dict__[c]
+                if type(value) is bool:
+                    values[c] = '1' if value else '0'
+                elif value is not None:
+                    values[c] = str(self.__dict__[c])
+            else:
+                values[c] = None
+
+        values_keys = ",".join(f":{k}" for k in values.keys())
+        command = f"INSERT INTO {self.table.name} VALUES ({values_keys})"
+        cursor.execute(command, values)
+
+
+def get_latest_table_name(cursor: sqlite3.Cursor) -> Optional[str]:
+    results = cursor.execute("SELECT name FROM sqlite_master").fetchall()
+    if len(results) > 0:
+        return sorted(results)[-1][0]
+    return None
+
+
+def get_next_table_name(cursor: sqlite3.Cursor) -> str:
+    latest_name = get_latest_table_name(cursor)
+    if latest_name:
+        # This assumes a name format of "comparisons_XYZ"
+        latest_id = int(latest_name.split('_')[1])
+    else:
+        latest_id = 0
+    return f"comparisons_{latest_id+1:03}"
+
+            
+class SqliteDumper:
+    def __init__(self, db_file: pathlib.Path) -> None:
+        self.con = sqlite3.connect(db_file)  # Creates the db if it doesn't already exist
+        self.cur = self.con.cursor()
+        table_name = get_next_table_name(self.cur)
+        self.table = dbComparisonTable(table_name)
+        logger.warning(f"Writing to db table {table_name}.")
+        self.table.createTable(self.cur)
+        self.con.commit()
+
+    def close(self):
+        self.con.close()
+        logger.warning(f"Finished writing to db table {self.table.name}.")
+
+    def update(self, line: str) -> None:
+        comp = None
+        try:
+            comp = ResponseComparison.from_json(line)
+        except InvalidJsonForLoadingComparisonException as e:
+            logger.error(f"Comparison could not be loaded due to invalid json. Skipping line. Details: {e}")
+        except MissingFieldForLoadingComparisonJsonException as e:
+            logger.error(f"Comparison could not be loaded due to a missing field. Skipping line. Details: {e}")
+
+        if comp is None:
+            return
+        
+        row = dbComparisonRow(self.table, comp)
+        row.writeRow(self.cur)
+        self.con.commit()
+        


### PR DESCRIPTION
Signed-off-by: Mikayla Thompson <thomika@amazon.com>### Description
[Describe what this change achieves]
New Feature

This adds 
1. A command to the traffic comparator that dumps comparison results to a sqlite database
2. A sample Jupyter notebook file (`Results Repository.ipynb`) that loads this data and performs a small selection of analysis and visualization steps.
3. A fairly comprehensive walkthrough of how to use this notebook and what happens in the first two cells.

### Issues Resolved
[MIGRATIONS-1076](https://opensearch.atlassian.net/browse/MIGRATIONS-1076)


### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [X] New functionality includes testing
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check 
[here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
