### PR TITLE
Set path to db with an env var in the notebook

### DIFF
--- a/ResultsRepository.ipynb
+++ b/ResultsRepository.ipynb
@@ -11,6 +11,7 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
+    "import os\n",
     "from pathlib import Path\n",
     "import sqlite3\n",
     "\n",
@@ -24,7 +25,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "db_file = Path(\"comparisons.db\")\n",
+    "db_file = Path(os.getenv(\"COMPARISONS_DB_LOCATION\", \"comparisons.db\"))\n",
+    "print(f\"Loading from DB file: {db_file}\")\n",
     "con = sqlite3.connect(db_file)\n",
     "cur = con.cursor()\n",
     "# By default, this reads from the latest table, but this can be modified to a specific table name instead.\n",


### PR DESCRIPTION
### Description / Issues Resolved
Encountered a small issue where the default db location in the notebook didn't correspond to the setup on the containers and needed a manual intervention. This essentially automates that intervention by letting the user set an environment variable with the path to their comparisons db.

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Manual testing

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check 
[here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
